### PR TITLE
Use spec-prod instead of spec-generator; also validate PRs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,19 +17,23 @@ jobs:
     steps:
       - name: Checkout git repository
         uses: actions/checkout@v4
-      - name: spec-generator
-        run: |
-          mkdir _site
-          tar cf guidelines.tar *
-          curl https://labs.w3.org/spec-generator/?type=respec -F file=@guidelines.tar -o _site/index.html -f --retry 3
-          cp *.png _site
+      - name: Run spec-prod
+        uses: w3c/spec-prod@v2
+
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Download spec-prod-result artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: spec-prod-result
+          path: _site
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
-        with:
-          path: _site
 
   deploy:
-    needs: build
+    needs: upload
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -1,0 +1,11 @@
+name: PR Spec Validation
+on: pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout git repository
+        uses: actions/checkout@v4
+      - name: Run spec-prod
+        uses: w3c/spec-prod@v2

--- a/respec-config.js
+++ b/respec-config.js
@@ -75,6 +75,12 @@ var respecConfig = {
 	group: "ag",
 	github: "w3c/wai-wcag-em",
 	
-	maxTocLevel: 4
+	maxTocLevel: 4,
 	
+	postProcess: [
+		() => {
+			// Remove stray <p> elements added by Markdown between dt/dd elements
+			document.querySelectorAll("dl > p:empty").forEach((el) => el.remove());
+		}
+	]
 };

--- a/scope.md
+++ b/scope.md
@@ -42,7 +42,7 @@ This methodology is applicable to the broad variety of website types. The follow
 **Note:** Due to the many possibilities of generating content and functionality in web applications it is sometimes not feasible to exhaustively identify every possible web page, web page state, and functionality. Web applications will typically require more time and effort to evaluate, and they will typically need larger web page samples to reflect the different types of content, functionality, and processes.</dd>
 
 <dt id="separable">Website with Separable Areas</dt>
-<dd>In some cases websites may have clearly separable areas where using one area does not require or depend on using another area of the website. For example, an organization might provide an extranet for its employees only that is linked from the public website but is otherwise separate, or it might have sub-sites for individual departments of the organization that are each clearly distinct from one another. Such separable areas can be considered as individual websites each for evaluation. In some cases there may be [common web pages](#common), such as legal notices, that need to be considered as part of each website area.</dd>
+<dd>In some cases websites may have clearly separable areas where using one area does not require or depend on using another area of the website. For example, an organization might provide an extranet for its employees only that is linked from the public website but is otherwise separate, or it might have sub-sites for individual departments of the organization that are each clearly distinct from one another. Such separable areas can be considered as individual websites each for evaluation. In some cases there may be [common web pages](#common), such as legal notices, that need to be considered as part of each website area.
 
 **Note:** Some websites provide additional or different content and functionality depending on the user (typically after a log-in). This additional content and functionality is generally part of the essential purpose and functionality of the website and is thus not considered to be a separable website area.</dd>
 
@@ -55,7 +55,7 @@ This methodology is applicable to the broad variety of website types. The follow
 <dd>Responsive design techniques adjust the order, flow, and sometimes behavior of the content to best suit the device on which it is used. For example, to adjust the content and functionality according to the size of the viewport, screen resolution, orientation of the screen, and other aspects of a mobile device and the context in which it is being used. In this methodology such changes to the content, functionality, appearance, and behavior are not considered to be independent website versions but rather [web page states](#states) that need to be included in the evaluation scope.
 
 **Note:** Considerations for mobile devices, operating systems, and assistive technologies need to be taken for websites using responsive design techniques, in particular during [Step 1.c: Define an Accessibility Support Baseline](#step1c).</dd>
-</dl
+</dl>
 
 ### Particular Evaluation Contexts
 


### PR DESCRIPTION
This improves the GitHub workflow from #2 to use the spec-prod GitHub action, which avoids relying on the live `spec-generator` service and is also capable of validating the document's HTML and CSS.

In the process, it found a few validation errors, which I've fixed. I needed to resort to a post-processing step for some of them, due to Markdown generating extra paragraph elements where they don't belong. (I first attempted resolving this manually by deleting some newlines, but that didn't seem to make a difference.)

I opened a test PR on my fork to verify the PR validation action, which intentionally has one failed run and one successful run among its commit history: https://github.com/kfranqueiro/wai-wcag-em/pull/1

You can also see the [output generated by the deploy process](https://github.com/kfranqueiro/wai-wcag-em/actions/runs/14779535670) on my fork. The artifacts contain `index.html` plus the two images, consistent with the current output.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/kfranqueiro/wai-wcag-em/pull/21.html" title="Last updated on May 1, 2025, 5:15 PM UTC (63d9d10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/21/f80d6aa...kfranqueiro:63d9d10.html" title="Last updated on May 1, 2025, 5:15 PM UTC (63d9d10)">Diff</a>