### PR TITLE
docs: fold background reading adn terms into appendices

### DIFF
--- a/appendices.md
+++ b/appendices.md
@@ -1,10 +1,122 @@
 ## Appendices
 
-### Appendix A: Contributors
+### Background reading {#reading}
+
+The information below, related to accessibility essentials, evaluation, and WCAG 2 is important for using this methodology. Evaluators using this methodology are expected to be deeply familiar with all the listed resources:
+
+#### Web Accessibility Essentials
+
+The following documents introduce the essential components of accessibility and explain how people with disabilities use the Web. They are critical for understanding the broader context of accessibility evaluation:
+
+* [Essential Components of Web Accessibility](https://www.w3.org/WAI/fundamentals/components/)
+* [How People with Disabilities Use the Web](https://www.w3.org/WAI/people-use-web/)
+
+#### Evaluating Digital Products for Accessibility
+
+These are particularly important resources that outline different approaches for evaluating digital products for accessibility:
+
+* [Easy Checks - A First Review of Web Accessibility](https://www.w3.org/WAI/test-evaluate/easy-checks/)
+* [Involving Users in Web Accessibility Evaluation](https://www.w3.org/WAI/test-evaluate/involving-users/)
+* [Selecting Web Accessibility Evaluation Tools](https://www.w3.org/WAI/test-evaluate/tools/selecting/)
+* [Using Combined Expertise to Evaluate Web Accessibility](https://www.w3.org/WAI/test-evaluate/combined-expertise/)
+
+#### Web Content Accessibility Guidelines (WCAG) 2
+
+This is the internationally recognized standard explaining how to make web content more accessible to people with disabilities. The following resources are particularly important for accessibility evaluation of digital products:
+
+* [WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/)
+* [WCAG 2.2 Technical Specification](https://www.w3.org/TR/WCAG22)
+* [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
+* [Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/)
+* [Techniques for WCAG 2.2](https://www.w3.org/WAI/WCAG22/Techniques/)
+
+#### ICT Accessibility
+* [Guidance on Applying WCAG 2.2 to Mobile Applications (WCAG2Mobile)](https://www.w3.org/TR/wcag2mobile-22/)
+* [Guidance on Applying WCAG 2 to Non-Web Information and Communications Technologies (WCAG2ICT)](https://www.w3.org/TR/wcag2ict-22/)
+
+#### Other Standards which incorporate WCAG 2 by reference 
+
+* [Section 508 of the Rehabilitation Act](https://www.access-board.gov/ict/)
+* [EN 301 549 (PDF)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf)
+ 
+
+### Glossary
+
+For the purposes of this document, the following terms and definitions apply:
+
+<dl>
+<dt id="complete">Complete processes</dt>
+<dd> Based on <a href="https://www.w3.org/TR/WCAG22/#cc3">WCAG 2.2 Conformance Requirement for Complete Processes</a>: 
+
+When a user interface is one of a series of user interfaces presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all user interfaces in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</dd>
+
+<dt id="conformance">Conformance</dt>
+<dd>From <a href="https://www.w3.org/TR/WCAG/#dfn-conform">WCAG 2.2 definition for "conformance"</a>:  
+<blockquote>Satisfying all the requirements of a given standard, guideline or specification.</blockquote></dd>
+
+<dt id="common">Common user interfaces</dt>
+<dd>User interfaces and <em>user interface states</em> that are relevant to the entire digital product. This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar user interfaces that are typically linked from all other user interfaces (usually from the header, footer, or navigation menu of a user interface).
+
+**Note:** A definition for [user interface states](#states) is provided below.</dd>
+
+<dt id="developer">Developer</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that is involved in the  development process including but not limited to content authors, designers, front-end developers, back-end programmers, quality assurance testers, and project managers.</dd>
+
+<dt id="website">Digital product</dt>
+<dd>A coherent collection of one or more related user interfaces that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
+
+**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of user interfaces, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</dd>
+
+<dt id="functionality">Essential functionality</dt>
+<dd>Functionality of a digital product that, if removed, fundamentally changes the use or purpose of the product for users. This includes information that users of a product refer to and tasks that they carry out to perform this functionality.
+
+**Note:** Examples of essential functionality include “selecting and purchasing an item from an online shop”, “completing and submitting a form provided in an application”, and “registering for an account on the kiosk”.
+
+**Note:** Other functionality is not excluded from the scope of evaluation. The term “essential functionality” is intended to help identify critical samples and include them among others in an evaluation.</dd>
+
+<dt id="evaluator">Evaluator</dt>
+<dd>The person, team of people, organization, in-house department, or other entity responsible for carrying out the evaluation.</dd>
+
+<dt id="commissioner">Evaluation commissioner</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that commissioned the evaluation.
+
+**Note:** In many cases the evaluation commissioner may be the product owner or product developer, in other cases it may be another entity such as a procurer or an accessibility monitoring survey owner.</dd>
+
+<dt id="relied">Relied upon (Technologies)</dt>
+
+<dd>From <a href="https://www.w3.org/TR/WCAG22/#dfn-reliedupon">WCAG 2.2 definition for "relied upon"</a>:  
+<blockquote>The content would not conform if that technology is turned off or is not supported.</blockquote></dd>
+
+<dt id="sample">Sample</dt>
+<dd>The entirety of a web page, document page, app screen, or a subset of the aformentioned.</dd>
+
+<dt id="template">Templates</dt>
+
+<dd>From <a href="https://www.w3.org/TR/ATAG20/#def-Template">ATAG 2.0 definition for "templates"</a>:  
+<blockquote>Content patterns that are filled in by authors or the authoring tool to produce web content for end users (e.g., document templates, content management templates, presentation themes). Often templates will pre-specify at least some authoring decisions.</blockquote></dd>
+
+<dt id="owner">Owner</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that is responsible for the digital product.</dd>
+
+<dt id="userinterface">User interface</dt>
+<dd>Content and interactive content that is perceivable to a user without <a href="https://www.w3.org/TR/WCAG22/#dfn-change-of-context">changes of context</a></dd>
+
+<dt id="states">User interface states</dt>
+<dd>Dynamically generated user interfaces sometimes provide significantly different content, functionality, and appearance depending on the user, interaction, device, and other parameters. In the context of this methodology such user interface states can be treated as ancillary to user interfaces (recorded as an additional state of a user interfaces in a sample) or as individual user interfaces.
+
+**Note:** Examples of user interface states are the individual parts of a multi-part form that are dynamically generated depending on the user's input. These individual states may need to be identified by describing the settings, input, and actions required to generate them.</dd>
+
+<dt id="webpage">Web page</dt>
+<dd>From <a href="https://www.w3.org/TR/WCAG22/#dfn-webpage">WCAG 2.2 definition for "web page"</a>:  
+<blockquote>A non-embedded resource obtained from a single URI using HTTP plus any other resources that are used in the rendering or intended to be rendered together with it by a user agent.</blockquote></dd>
+</dl>
+
+
+### Contributors
 
 Past and present active participants of the [WCAG 2.0 Evaluation Methodology Task Force (Eval TF)](https://www.w3.org/WAI/ER/2011/eval/eval-tf) include: Shadi Abou-Zahra; Frederick Boland; Denis Boudreau; Amy Chen; Vivienne Conway; Bim Egan; Michael Elledge; Gavin Evans; Wilco Fiers; Detlev Fischer; Elizabeth Fong; Vincent François; Alistair Garrison; Emmanuelle Gutiérrez y Restrepo; Katie Haritos-Shea; Martijn Houtepen; Peter Korn; Maureen Kraft; Aurelien Levy; David MacDonald; Mary Jo Mueller; Donald Raikes; Corominas Ramon; Roberto Scano; Samuel Sirois; Sarah J Swierenga; Eric Velleman; Konstantinos Votis; Kathleen Wahlbin; Elle Waters; Richard Warren; Léonie Watson.
 
-### Appendix B: References
+### References
 
 <dl>
   <dt>ATAG20</dt>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,6 @@
     <section id="usage" data-include="usage.md" data-include-format="markdown"></section>
     <section id="scope" data-include="scope.md" data-include-format="markdown"></section>
     <section id="procedure" data-include="procedure.md" data-include-format="markdown"></section>
-    <section id="background" data-include="background-reading.md" data-include-format="markdown"></section>
-    <section id="terms" data-include="terms.md" data-include-format="markdown"></section>
     <section id="appendices" data-include="appendices.md" data-include-format="markdown"></section>
 
     <script type="application/javascript" src="https://www.w3.org/scripts/TR/fixup.js"></script>


### PR DESCRIPTION
- removed the numbering of appendices 
- added background reading and glossary as appendices
- renamed 'terms and definitions' to glossary to match wording of WCAG, where it is called 'glossary'


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/50.html" title="Last updated on Jul 8, 2025, 12:51 PM UTC (b18d7c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/50/776204e...b18d7c7.html" title="Last updated on Jul 8, 2025, 12:51 PM UTC (b18d7c7)">Diff</a>