### PR TITLE
docs: add responsible + version number in about

### DIFF
--- a/procedure.md
+++ b/procedure.md
@@ -300,7 +300,7 @@ Documenting the outcomes for each step includes at least the following:
     *   Name of the [evaluator](#evaluator)
     *   Name of the [evaluation commissioner](#commissioner)
     *   Date of the evaluation (completion date or duration period)
-    *   Optional: list of dates, such as the date of the initial report and dates of repeat evaluations (version numbers are recommended).
+    *   Optional: list of dates, such as the date of the initial report and dates of repeat evaluations (version numbers are recommended)
     *   Optional: name of the person, team or organisation responsible for the digital product (this may be different from the evaluation commissioner)
 *   **Evaluation Scope**
     *   Scope of the digital product defined in [Step 1.a: Define the Scope of the Digital Product](#step1a)

--- a/procedure.md
+++ b/procedure.md
@@ -299,8 +299,8 @@ Documenting the outcomes for each step includes at least the following:
 *   **About the Evaluation**
     *   Name of the [evaluator](#evaluator)
     *   Name of the [evaluation commissioner](#commissioner)
-* Date of the evaluation (completion date or duration period)
-* Optional: list of dates, such as the date of the initial report and dates of repeat evaluations (version numbers are recommended).
+    *   Date of the evaluation (completion date or duration period)
+    *   Optional: list of dates, such as the date of the initial report and dates of repeat evaluations (version numbers are recommended).
     *   Optional: name of the person, team or organisation responsible for the digital product (this may be different from the evaluation commissioner)
 *   **Evaluation Scope**
     *   Scope of the digital product defined in [Step 1.a: Define the Scope of the Digital Product](#step1a)

--- a/procedure.md
+++ b/procedure.md
@@ -300,6 +300,8 @@ Documenting the outcomes for each step includes at least the following:
     *   Name of the [evaluator](#evaluator)
     *   Name of the [evaluation commissioner](#commissioner)
     *   Date for the evaluation (completion date or duration period)
+    *   Optional: name of the person, team or organisation responsible for the digital product (this may be different from the evaluation commissioner)
+    *   Optional: version number for the evaluation
 *   **Evaluation Scope**
     *   Scope of the digital product defined in [Step 1.a: Define the Scope of the Digital Product](#step1a)
     *   Conformance target defined in [Step 1.b. Define the Conformance Target](#step1b)

--- a/procedure.md
+++ b/procedure.md
@@ -299,9 +299,9 @@ Documenting the outcomes for each step includes at least the following:
 *   **About the Evaluation**
     *   Name of the [evaluator](#evaluator)
     *   Name of the [evaluation commissioner](#commissioner)
-    *   Date for the evaluation (completion date or duration period)
+* Date of the evaluation (completion date or duration period)
+* Optional: list of dates, such as the date of the initial report and dates of repeat evaluations (version numbers are recommended).
     *   Optional: name of the person, team or organisation responsible for the digital product (this may be different from the evaluation commissioner)
-    *   Optional: version number for the evaluation
 *   **Evaluation Scope**
     *   Scope of the digital product defined in [Step 1.a: Define the Scope of the Digital Product](#step1a)
     *   Conformance target defined in [Step 1.b. Define the Conformance Target](#step1b)


### PR DESCRIPTION
Add responsible: this helps people who monitor many websites to understand where to send compliments or complaints, this is not necessarily the commissioner.

Add version number: this helps understand the progress when multiple evaluations were done.

fixes #58 fixes #59


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/60.html" title="Last updated on Jul 10, 2025, 3:25 PM UTC (5462871)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/60/2fece25...5462871.html" title="Last updated on Jul 10, 2025, 3:25 PM UTC (5462871)">Diff</a>