### PR TITLE
Use view instead of user interface to align with latest WCAG 3 glossary update

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ python3 -m http.server 8000 & sleep 2 && open http://localhost:8000
 
 ### All changes
 
+- 13 August 2025: use WCAG 3 developing definition “view” instead of “user interface” and remove “user interface states” for now.
 - 14 July 2025: to suggested content of report, add new meta data for “About the evaluation”: list of dates incl mention of repeat evaluation and version numbers; name of person, team or organisation responsible for the product (may be different from the commissioner).
 - 10 July 2025: move background reading and terms into appendices, call terms “Glossary” (to align with WCAG 22 wording). Add method for sampling that can work without web pages, that suggests to manually list all UI. ([cd17e12](https://github.com/w3c/wai-wcag-em/commit/cd17e1283f417efb733e23fa3e1dff595a2587b7))
 - 8 July 2025: simplify introduction, use active verbs, a list for factors and 'target audience' instead of 'purpose', move terms and background reading to end of document ([b3ceab3](https://github.com/w3c/wai-wcag-em/commit/b3ceab3c7fb4508053ef10be8e16e9dbdfa45eba)).

--- a/appendices.md
+++ b/appendices.md
@@ -48,7 +48,7 @@ For the purposes of this document, the following terms and definitions apply:
 <dt id="complete">Complete processes</dt>
 <dd> Based on <a href="https://www.w3.org/TR/WCAG22/#cc3">WCAG 2.2 Conformance Requirement for Complete Processes</a>: 
 
-When a <a href="#view">view</a> is one of a series of views presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all views in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</dd>
+When a <a href="#view">view</a> is one of a series of views presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all views in the process conform at the specified level or better. (Conformance is not possible at a particular level if any view in the process does not conform at that level or better.)</dd>
 
 <dt id="conformance">Conformance</dt>
 <dd>From <a href="https://www.w3.org/TR/WCAG/#dfn-conform">WCAG 2.2 definition for "conformance"</a>:  

--- a/appendices.md
+++ b/appendices.md
@@ -48,24 +48,24 @@ For the purposes of this document, the following terms and definitions apply:
 <dt id="complete">Complete processes</dt>
 <dd> Based on <a href="https://www.w3.org/TR/WCAG22/#cc3">WCAG 2.2 Conformance Requirement for Complete Processes</a>: 
 
-When a user interface is one of a series of user interfaces presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all user interfaces in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</dd>
+When a <a href="#view">view</a> is one of a series of views presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all views in the process conform at the specified level or better. (Conformance is not possible at a particular level if any page in the process does not conform at that level or better.)</dd>
 
 <dt id="conformance">Conformance</dt>
 <dd>From <a href="https://www.w3.org/TR/WCAG/#dfn-conform">WCAG 2.2 definition for "conformance"</a>:  
 <blockquote>Satisfying all the requirements of a given standard, guideline or specification.</blockquote></dd>
 
-<dt id="common">Common user interfaces</dt>
-<dd>User interfaces and <em>user interface states</em> that are relevant to the entire digital product. This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar user interfaces that are typically linked from all other user interfaces (usually from the header, footer, or navigation menu of a user interface).
+<dt id="common">Common views</dt>
+<dd>Views and different states that are relevant to the entire digital product. This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar views that are typically linked from all other views (usually from the header, footer, or navigation menu).
 
-**Note:** A definition for [user interface states](#states) is provided below.</dd>
+**Note:** A definition for [views](#view) is provided below.</dd>
 
 <dt id="developer">Developer</dt>
 <dd>The person, team of people, organization, in-house department, or other entity that is involved in the  development process including but not limited to content authors, designers, front-end developers, back-end programmers, quality assurance testers, and project managers.</dd>
 
 <dt id="digital-product">Digital product</dt>
-<dd>A coherent collection of one or more related user interfaces that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
+<dd>A coherent collection of one or more related views that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
 
-**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of user interfaces, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</dd>
+**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</dd>
 
 <dt id="functionality">Essential functionality</dt>
 <dd>Functionality of a digital product that, if removed, fundamentally changes the use or purpose of the product for users. This includes information that users of a product refer to and tasks that they carry out to perform this functionality.
@@ -98,13 +98,9 @@ When a user interface is one of a series of user interfaces presenting a process
 <dt id="owner">Owner</dt>
 <dd>The person, team of people, organization, in-house department, or other entity that is responsible for the digital product.</dd>
 
-<dt id="userinterface">User interface</dt>
-<dd>Content and interactive content that is perceivable to a user without <a href="https://www.w3.org/TR/WCAG22/#dfn-change-of-context">changes of context</a></dd>
-
-<dt id="states">User interface states</dt>
-<dd>Dynamically generated user interfaces sometimes provide significantly different content, functionality, and appearance depending on the user, interaction, device, and other parameters. In the context of this methodology such user interface states can be treated as ancillary to user interfaces (recorded as an additional state of a user interfaces in a sample) or as individual user interfaces.
-
-**Note:** Examples of user interface states are the individual parts of a multi-part form that are dynamically generated depending on the user's input. These individual states may need to be identified by describing the settings, input, and actions required to generate them.</dd>
+<dt id="view">View</dt>
+<dd>From WCAG 3 developing definition:  
+<blockquote>The content that is actively available in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</blockquote></dd>
 
 <dt id="webpage">Web page</dt>
 <dd>From <a href="https://www.w3.org/TR/WCAG22/#dfn-webpage">WCAG 2.2 definition for "web page"</a>:  

--- a/appendices.md
+++ b/appendices.md
@@ -65,7 +65,8 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 <dt id="digital-product">Digital product</dt>
 <dd>A coherent collection of one or more related views that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
 
-**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</dd>
+<p class="note">
+**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</p></dd>
 
 <dt id="functionality">Essential functionality</dt>
 <dd>Functionality of a digital product that, if removed, fundamentally changes the use or purpose of the product for users. This includes information that users of a product refer to and tasks that they carry out to perform this functionality.

--- a/appendices.md
+++ b/appendices.md
@@ -57,7 +57,7 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 <dt id="common">Common views</dt>
 <dd>Views and different states that are relevant to the entire digital product. This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar views that are typically linked from all other views (usually from the header, footer, or navigation menu).
 
-**Note:** A definition for [views](#view) is provided below.</dd>
+<p class="note">A definition for <a href="#view">views</a> is provided below.</p></dd>
 
 <dt id="developer">Developer</dt>
 <dd>The person, team of people, organization, in-house department, or other entity that is involved in the  development process including but not limited to content authors, designers, front-end developers, back-end programmers, quality assurance testers, and project managers.</dd>
@@ -65,15 +65,12 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 <dt id="digital-product">Digital product</dt>
 <dd>A coherent collection of one or more related views that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
 
-<p class="note">
-**Note:** The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</p></dd>
+<p class="note">The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</p></dd>
 
 <dt id="functionality">Essential functionality</dt>
 <dd>Functionality of a digital product that, if removed, fundamentally changes the use or purpose of the product for users. This includes information that users of a product refer to and tasks that they carry out to perform this functionality.
-
-**Note:** Examples of essential functionality include “selecting and purchasing an item from an online shop”, “completing and submitting a form provided in an application”, and “registering for an account on the kiosk”.
-
-**Note:** Other functionality is not excluded from the scope of evaluation. The term “essential functionality” is intended to help identify critical samples and include them among others in an evaluation.</dd>
+<p class="note">Examples of essential functionality include “selecting and purchasing an item from an online shop”, “completing and submitting a form provided in an application”, and “registering for an account on the kiosk”.</p>
+<p class="note">Other functionality is not excluded from the scope of evaluation. The term “essential functionality” is intended to help identify critical samples and include them among others in an evaluation.</p></dd>
 
 <dt id="evaluator">Evaluator</dt>
 <dd>The person, team of people, organization, in-house department, or other entity responsible for carrying out the evaluation.</dd>
@@ -81,7 +78,7 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 <dt id="commissioner">Evaluation commissioner</dt>
 <dd>The person, team of people, organization, in-house department, or other entity that commissioned the evaluation.
 
-**Note:** In many cases the evaluation commissioner may be the product owner or product developer, in other cases it may be another entity such as a procurer or an accessibility monitoring survey owner.</dd>
+<p class="note">In many cases the evaluation commissioner may be the product owner or product developer, in other cases it may be another entity such as a procurer or an accessibility monitoring survey owner.</p></dd>
 
 <dt id="relied">Relied upon (Technologies)</dt>
 

--- a/procedure.md
+++ b/procedure.md
@@ -14,7 +14,7 @@ During this step the overall scope of the evaluation is defined. It is a fundame
 
 #### Step 1.1: Define the Scope of the Product  {#step1a}
 
-<strong id="req1a">Methodology Requirement 1.1:</strong> Define the target [digital product](#digital-product) according to [Scope of Applicability](#applicability), so that for each [user interface](#webpage) it is unambiguous whether it is within the scope of evaluation or not.
+<strong id="req1a">Methodology Requirement 1.1:</strong> Define the target [digital product](#digital-product) according to [Scope of Applicability](#applicability), so that for each [view](#view) it is unambiguous whether it is within the scope of evaluation or not.
 
 During this step the target product (the samples and states of samples that are in scope of the evaluation) is defined. This scope of the product is defined according to the terms established in the section [Scope of Applicability](#applicability).
 
@@ -52,7 +52,7 @@ During this step the evaluator determines the minimum set of combinations of ope
 
 An evaluation commissioner may be interested in additional information beyond what is needed to evaluate the extent of conformance of the target product to WCAG 2. For example, an evaluation commissioner might be interested in:
 
-*   Evaluation of additional user interfaces beyond what is needed to form a representative sample from the target digital product;
+*   Evaluation of additional views beyond what is needed to form a representative sample from the target digital product;
 *   Reports of all occurrences of issues rather than representative examples of the types of issues on the target digital product;
 *   Analysis of particular use cases, situations, and user groups for interacting with the target digital product;
 *   Description of possible solutions to the issues encountered beyond the scope of the evaluation;

--- a/scope.md
+++ b/scope.md
@@ -39,22 +39,22 @@ This methodology is applicable to the broad variety of website types. The follow
 <dt>Web Applications</dt>
 <dd>Web applications are generally composed of dynamically generated content and functionality (see <a href="#states">web page states</a>). Web applications tend to be more complex and interactive. Some examples of web applications include webmail clients, document editors, and online shops. Web applications may be part of a larger website but can also constitute a website of their own in the context of this methodology. That is, an individual and separable entity for evaluation.
 
-**Note:** Due to the many possibilities of generating content and functionality in web applications it is sometimes not feasible to exhaustively identify every possible web page, web page state, and functionality. Web applications will typically require more time and effort to evaluate, and they will typically need larger web page samples to reflect the different types of content, functionality, and processes.</dd>
+<p class="note">Due to the many possibilities of generating content and functionality in web applications it is sometimes not feasible to exhaustively identify every possible web page, web page state, and functionality. Web applications will typically require more time and effort to evaluate, and they will typically need larger web page samples to reflect the different types of content, functionality, and processes.</p></dd>
 
 <dt id="separable">Website with Separable Areas</dt>
 <dd>In some cases websites may have clearly separable areas where using one area does not require or depend on using another area of the website. For example, an organization might provide an extranet for its employees only that is linked from the public website but is otherwise separate, or it might have sub-sites for individual departments of the organization that are each clearly distinct from one another. Such separable areas can be considered as individual websites each for evaluation. In some cases there may be <a href="#common">common web pages</a>, such as legal notices, that need to be considered as part of each website area.
 
-**Note:** Some websites provide additional or different content and functionality depending on the user (typically after a log-in). This additional content and functionality is generally part of the essential purpose and functionality of the website and is thus not considered to be a separable website area.</dd>
+<p class="note">Some websites provide additional or different content and functionality depending on the user (typically after a log-in). This additional content and functionality is generally part of the essential purpose and functionality of the website and is thus not considered to be a separable website area.</p></dd>
 
 <dt>Website in Multiple Versions</dt>
 <dd>Some websites are available in multiple versions that are independent of one another in use, that is, using one version does not require or depend on using another version of the website. For example, a website may have a mobile version and there may be versions of a website in different languages that meet this characteristic. Usually each such website version has a different set of URIs. Such website versions can be considered as individual websites for evaluation.
 
-**Note:** Websites using responsive design techniques (i.e. adapting the presentation according to user hardware, software, and preferences) as opposed to redirecting the user to a different location are not considered to be independent website versions.</dd>
+<p class="note">Websites using responsive design techniques (i.e. adapting the presentation according to user hardware, software, and preferences) as opposed to redirecting the user to a different location are not considered to be independent website versions.</p></dd>
 
 <dt>Website Using Responsive Design</dt>
 <dd>Responsive design techniques adjust the order, flow, and sometimes behavior of the content to best suit the device on which it is used. For example, to adjust the content and functionality according to the size of the viewport, screen resolution, orientation of the screen, and other aspects of a mobile device and the context in which it is being used. In this methodology such changes to the content, functionality, appearance, and behavior are not considered to be independent website versions but rather <a href="#states">web page states</a> that need to be included in the evaluation scope.
 
-**Note:** Considerations for mobile devices, operating systems, and assistive technologies need to be taken for websites using responsive design techniques, in particular during <a href="#step1c">Step 1.c: Define an Accessibility Support Baseline</a>.</dd>
+<p class="note">Considerations for mobile devices, operating systems, and assistive technologies need to be taken for websites using responsive design techniques, in particular during <a href="#step1c">Step 1.c: Define an Accessibility Support Baseline</a>.</p></dd>
 </dl>
 
 ### Particular Evaluation Contexts


### PR DESCRIPTION
- removed 'user interface states' , we can add that level of detail later
- did not link to the definition yet, I think it will only ship when we deploy a next version of the working draft so we can tweak that later (same for links within the def to 'content' and 'actively available')


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/73.html" title="Last updated on Aug 15, 2025, 10:26 AM UTC (ede9675)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/73/83c625d...ede9675.html" title="Last updated on Aug 15, 2025, 10:26 AM UTC (ede9675)">Diff</a>