### PR TITLE
fix: unrendered markdown

### DIFF
--- a/procedure.md
+++ b/procedure.md
@@ -233,7 +233,7 @@ The five WCAG 2.2 conformance requirements are:
 
 Further guidance on evaluating to these conformance requirements is provided in the following sections. The [WCAG 2 Layers of Guidance](https://www.w3.org/TR/WCAG22/#wcag-2-layers-of-guidance) and [Understanding Conformance](https://www.w3.org/WAI/WCAG22/Understanding/conformance) provide more background and guidance on the WCAG 2 conformance requirements, which is beyond the scope of this document.
 
-<p class="note">Carrying out this step requires deep understanding of the WCAG 2 conformance requirements and the expertise described in section [Required Expertise](#expertise).</p>
+<p class="note">Carrying out this step requires deep understanding of the WCAG 2 conformance requirements and the expertise described in section <a href="#expertise">Required Expertise</a>.</p>
 
 #### Step 4.1: Check All Initial Samples {#step4a}
 


### PR DESCRIPTION
link was not rendering

fixes #93


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/97.html" title="Last updated on Sep 16, 2025, 10:04 AM UTC (48e3261)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/97/278599b...48e3261.html" title="Last updated on Sep 16, 2025, 10:04 AM UTC (48e3261)">Diff</a>