### PR TITLE
Tweak wording + make 'skip sampling' option (incl for some apps, documents) more explicit

### DIFF
--- a/abstract.md
+++ b/abstract.md
@@ -1,5 +1,5 @@
-This document describes a procedure to evaluate how well digital services and products conform to the [Web Content Accessibility Guidelines (WCAG) 2](https://www.w3.org/WAI/standards-guidelines/wcag/). 
+This document describes a procedure to evaluate how well digital products conform to the [Web Content Accessibility Guidelines (WCAG) 2](https://www.w3.org/WAI/standards-guidelines/wcag/). 
 
-It provides technology-agnostic guidance to define the evaluation scope, explore the target product, select a representative [sample set](#sampleset) from products, evaluate the selected [sample set](#sampleset), and report the evaluation findings. It is suitable for use in different evaluation contexts, including self-assessment and third-party evaluation. 
+It provides technology-agnostic guidance to define the evaluation scope, explore the target product, select a representative [sample set](#sampleset) from products, evaluate the selected [sample set](#sampleset), and report the evaluation findings. This procedure is suitable for use in different evaluation contexts, including self-assessment and third-party evaluation. 
 
 This document does not define feature-specific instructions, as the WCAG Success Criteria and [supporting documents](https://www.w3.org/WAI/standards-guidelines/wcag/docs/) cover those. It also does not define additional WCAG 2 requirements, nor does it replace or supersede them in any way. 

--- a/appendices.md
+++ b/appendices.md
@@ -45,7 +45,7 @@ This is the internationally recognized standard that explains how to make web co
 For the purposes of this document, the following terms and definitions apply:
 
 <dl>
-<dt id="complete">Complete processes</dt>
+<dt id="complete">Complete process</dt>
 <dd> Based on <a href="https://www.w3.org/TR/WCAG22/#cc3">WCAG 2.2 Conformance Requirement for Complete Processes</a>: 
 
 When a <a href="#view">view</a> is one of a series of views presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all views in the process conform at the specified level or better. (Conformance is not possible at a particular level if any view in the process does not conform at that level or better.)</dd>
@@ -92,7 +92,7 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 <dd>List of <a href="#sample">samples</a> selected for evaluations.</dd>
 
 
-<dt id="template">Templates</dt>
+<dt id="template">Template</dt>
 
 <dd>From <a href="https://www.w3.org/TR/ATAG20/#def-Template">ATAG 2.0 definition for "templates"</a>:  
 <blockquote>Content patterns that are filled in by authors or the authoring tool to produce web content for end users (e.g., document templates, content management templates, presentation themes). Often templates will pre-specify at least some authoring decisions.</blockquote></dd>

--- a/procedure.md
+++ b/procedure.md
@@ -112,17 +112,17 @@ Such additional evaluation requirements that are agreed on with the evaluator ne
 
 <p class="methodology-requirement"><strong id="req2">Methodology Requirement 2:</strong> Explore the digital product to be evaluated according to <a href="#req2a">Methodology Requirement 2.1</a>, <a href="#req2b">Methodology Requirement 2.2</a>, <a href="#req2c">Methodology Requirement 2.3</a>, <a href="#req2d">Methodology Requirement 2.4</a>, and <a href="#req2e">Methodology Requirement 2.5</a>.</p>
 
-During this step the evaluator explores the target product to be evaluated, to develop an initial understanding of the product and its use, purpose, and functionality. Much of this will not be immediately apparent to evaluators, in particular to those from outside the development team. In some cases it is also not possible to exhaustively identify and list all functionality, types of samples, and technologies used to realize the product and its applications. The initial exploration carried out in this step is typically refined in the later steps [Step 3: Select a Representative Sample Set](#step3) and [Step 4: Evaluate the Selected Sample Set](#step4), as the evaluator learns more about the target product. Involvement of product owners and product developers can help evaluators make their explorations more effective.
+During this step the evaluator explores the target product to be evaluated, to develop an initial understanding of the product and its use, purpose, and functionality. Much of this will not be immediately apparent to evaluators, in particular to those from outside the development team. In some cases it is also not possible to exhaustively identify and list all functionality, types of samples, and technologies used to realize the product. Involvement of product owners and product developers can help evaluators make their explorations more effective.
 
-<p class="note">Carrying out initial cursory checks during this step helps identify samples that are relevant for more detailed evaluation later on. For example, an evaluator may identify samples that seem to be lacking color contrast, document structure, or consistent navigation, and note them down for more detailed evaluation later on.
+<p class="note">Carrying out initial cursory checks during this step helps identify samples that are relevant for more detailed evaluation later on. For example, an evaluator may identify samples that seem to be lacking color contrast, document structure, or consistent navigation, and note them down for more detailed evaluation later on.</p>
 
 <p class="note">To carry out this step it is critical that the evaluator has access to all the relevant parts of the product. For example, it may be necessary to create accounts or otherwise provide access to restricted areas of a product that are part of the evaluation. Granting evaluators such access may require particular security and privacy precautions.</p>
 
 #### Step 2.1: Identify Common Samples of the Digital Product {#step2a}
 
-<p class="methodology-requirement"><strong id="req2a">Methodology Requirement 2.1:</strong> Identify the <a href="#common">common samples</a>, which may be sample states, of the target product.</p>
+<p class="methodology-requirement"><strong id="req2a">Methodology Requirement 2.1:</strong> Identify the <a href="#common">common views</a> of the target product.</p>
 
-Explore the target product to identify its common samples, which may also be sample states in web applications. Typically these are linked directly from the main entry point of the target product (like the home page on a website, or the start screen of an app), and often linked from the header, navigation, and footer sections of other samples. The outcome of this step is a list of all common pages or views of the target product.
+Explore the target product to identify its common views, which may also be specific states of views. Typically these are linked directly from the main entry point of the target product (like the home page on a website, or the start screen of an app), and often linked from the header, navigation, and footer sections of other samples. The outcome of this step is a list of all common pages or views of the target product.
 
 #### Step 2.2: Identify Essential Functionality of the Product {#step2b}
 

--- a/procedure.md
+++ b/procedure.md
@@ -204,7 +204,7 @@ Select a sample set that is representative of the target product to be evaluated
   <p>If it is feasible to evaluate the entire digital product, which is recommended, this sampling procedure may be skipped, meaning the entire digital product is evaluated.</p>
   <p>There are also other specific cases where it makes sense to skip the sampling procedure, and evaluate the entire digital product instead. Such cases include:</p>
   <ul>
-    <li>when the digital product has a small amount of views, for example in some native apps or kiosks,</li>
+    <li>when the digital product has a small number of views, for example in some native apps or kiosks,</li>
     <li>when the digital product cannot meaningfully be split into views, for example in certain kinds of documents.</li>
   </ul>
   <p>When the sampling procedure is skipped, use the entire product as “selected sample set” in the remaining steps of this evaluation process.</p>

--- a/procedure.md
+++ b/procedure.md
@@ -79,7 +79,7 @@ It is also important to document any particular aspects of the target product to
 
 WCAG 2 Level AA is the generally accepted and recommended target.
 
-<p class="note">It is often useful to evaluate beyond the conformance target of the digital product. For example, a product might meet individual requirements from a higher conformance level. Having and documenting this information can help plan future improvements more effectively.</p>
+<p class="note">It is often useful to evaluate beyond the conformance target of the digital product. For example, a product might meet individual requirements from a higher conformance level. Documenting this information can help plan future improvements more effectively.</p>
 
 #### Step 1.3: Define an Accessibility Support Baseline {#step1c}
 

--- a/procedure.md
+++ b/procedure.md
@@ -54,15 +54,18 @@ Evaluators can proceed from one step to the next, and may return to any precedin
 
 <p class="methodology-requirement"><strong id="req1">Methodology Requirement 1:</strong> Define the evaluation scope according to <a href="#req1a">Methodology Requirement 1.1</a>, <a href="#req1b">Methodology Requirement 1.2</a>, and <a href="#req1c">Methodology Requirement 1.3</a>, and optionally <a href="#req1d">Methodology Requirement 1.4</a>.</p>
 
-During this step the overall scope of the evaluation is defined. It is a fundamental step that affects the subsequent steps in the evaluation procedure. It is ideally carried out in consultation with the evaluation commissioner (who may or may _not_ be the product's owner) to ensure common expectations about the scope of the evaluation. Initial exploration of the target product during this step may be necessary to better know specifics of the product and the required evaluation. Detailed exploration of the product is carried out in [Step 2: Explore the Target Product](#step2).
+Usually, this step involves the evaluation commissioner (who may or may _not_ be the product's owner), to align expectations, and an initial exploration of the product.
 
 #### Step 1.1: Define the Scope of the Product  {#step1a}
 
 <p class="methodology-requirement"><strong id="req1a">Methodology Requirement 1.1:</strong> Define the target <a href="#digital-product">digital product</a> according to <a href="#applicability">Scope of Applicability</a>, so that for each <a href="#view">view</a> it is unambiguous whether it is within the scope of evaluation or not.</p>
 
-During this step the target product (the samples that are in scope of the evaluation) is defined. This scope of the product is defined according to the terms established in the section [Scope of Applicability](#applicability).
+Define the target product, taking into account the considerations in [Scope of Applicability](#applicability), for example:
 
-To avoid later mismatches of expectations between the evaluator, evaluation commissioner, and readers of the resulting evaluation report, it is important to define the target product so that it is unambiguous that a sample is within its scope. Using formalizations including [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) and listings of web addresses (URIs) is recommended where possible.
+- All content on https://example-museum.org.
+- All content on Example's Museum Shop, located on https://shop.example-museum.org, except for the Temporary Art Collection
+
+It is important to be clear and unambiguous in this step, and avoid any doubt regarding which views are in scope. Using formalizations including [regular expressions](https://en.wikipedia.org/wiki/Regular_expression) and listings of web addresses (URIs) is recommended where possible.
 
 It is also important to document any particular aspects of the target product to support its identification. This includes:
 
@@ -74,15 +77,15 @@ It is also important to document any particular aspects of the target product to
 
 <p class="methodology-requirement"><strong id="req1b">Methodology Requirement 1.2:</strong> Select a target WCAG 2 <a href="https://www.w3.org/TR/WCAG22/#cc1">conformance level</a> (“A”, “AA”, or “AAA”) for the evaluation.</p>
 
-Part of initiating the evaluation process is to define the target WCAG 2 conformance level ("A", "AA", or "AAA") for evaluation. WCAG 2 Level AA is the generally accepted and recommended target.
+WCAG 2 Level AA is the generally accepted and recommended target.
 
-<p class="note">It is often useful to evaluate beyond the conformance target of the digital product to get a more complete picture of its accessibility performance. For example, while a product might not fully meet a particular conformance level, it might meet individual requirements from a higher conformance level. Having this information can help plan future improvements more effectively.</p>
+<p class="note">It is often useful to evaluate beyond the conformance target of the digital product. For example, a product might meet individual requirements from a higher conformance level. Having and documenting this information can help plan future improvements more effectively.</p>
 
 #### Step 1.3: Define an Accessibility Support Baseline {#step1c}
 
 <p class="methodology-requirement"><strong id="req1c">Methodology Requirement 1.3:</strong> Define the web browser, assistive technologies and other <a href="https://www.w3.org/TR/WCAG22/#dfn-useragent">user agents</a> for which features provided on the digital product are to be <a href="https://www.w3.org/TR/WCAG22/#dfn-accessibility-supported">accessibility supported</a>.</p>
 
-Particularly for new technologies it is not always possible to ensure that every accessibility feature provided on a digital product, such as a 'show captions' function in a media player, is supported by every possible combination of operating system, web browser, assistive technology, and other user agents. WCAG 2 does not pre-define which combinations of features and technologies must be supported as this depends on the particular context of the product, including its language, the technologies that are used to create the content, and the user agents currently available. [Understanding Accessibility Support](https://www.w3.org/WAI/WCAG22/Understanding/conformance#accessibility-support) provides more guidance on the WCAG 2 concept of _accessibility support_.
+Particularly for new technologies it is not always possible to ensure that every accessibility feature provided on a digital product, such as a “Show captions” function in a media player, is supported by every possible combination of operating system, web browser, assistive technology, and other user agents. WCAG 2 does not pre-define which combinations of features and technologies must be supported as this depends on the particular context of the product, including its language, the technologies that are used to create the content, and the user agents currently available. [Understanding Accessibility Support](https://www.w3.org/WAI/WCAG22/Understanding/conformance#accessibility-support) provides more guidance on the WCAG 2 concept of _accessibility support_.
 
 During this step the evaluator determines the minimum set of combinations of operating systems, web browsers, assistive technologies, and other user agents that the product is expected to work with, and that is in-line with the WCAG 2 guidance on accessibility support (linked above). This step is carried out in consultation with the evaluation commissioner to ensure common expectation for the targeted level of accessibility support. The product's owner and product's developer may also have such a list of combinations that the product was designed to support, which could be a starting point for this step. Depending on the purpose of the evaluation such a list may need to be updated, for example to assess how well the product works with more current browsers.
 
@@ -193,9 +196,19 @@ Examples of other relevant samples include those:
 
 ### Step 3: Select a Representative Sample {#step3}
 
-<p class="methodology-requirement"><strong id="req3">Methodology Requirement 3:</strong> Select a representative sample set from the digial product according to <a href="#req3a">Methodology Requirement 3.1</a>, <a href="#req3b">Methodology Requirement 3.2</a>, and <a href="#req3c">Methodology Requirement 3.3</a>.</p>
+<p class="methodology-requirement"><strong id="req3">Methodology Requirement 3:</strong> Select a representative sample set from the digital product according to <a href="#req3a">Methodology Requirement 3.1</a>, <a href="#req3b">Methodology Requirement 3.2</a>, and <a href="#req3c">Methodology Requirement 3.3</a>.</p>
 
-During this step the evaluator selects a sample set that is representative of the target product to be evaluated. The purpose of this selection is to ensure that the evaluation results reflect the accessibility performance of the digital product with reasonable confidence. In cases where it is feasible to evaluate all pages or views of a digital product, which is highly recommended, this sampling procedure can be skipped and the “selected sample set” in the remaining steps of this evaluation process is the entire digital product. In some cases, such as for small websites, this sampling procedure may result in selecting all pages or views states of the website, or all screens of the mobile application.
+Select a sample set that is representative of the target product to be evaluated. This helps ensure that the evaluation results reflect the accessibility performance of the digital product with reasonable confidence. 
+
+<div class="note">
+  <p>If it is feasible to evaluate the entire digital product, which is recommended, this sampling procedure may be skipped, meaning the entire digital product is evaluated.</p>
+  <p>There are also other specific cases where it makes sense to skip the sampling procedure, and evaluate the entire digital product instead. Such cases include:</p>
+  <ul>
+    <li>when the digital product has a small amount of views, for example in some native apps or kiosks,</li>
+    <li>when the digital product cannot meaningfully be split into views, for example in certain kinds of documents.</li>
+  </ul>
+  <p>When the sampling procedure is skipped, use the entire product as “selected sample set” in the remaining steps of this evaluation process.</p>
+</div>
 
 <p id="samplesize">The actual size of the sample set needed to evaluate a digital product depends on many factors including:</p>
 

--- a/scope.md
+++ b/scope.md
@@ -1,6 +1,6 @@
 ## Scope of Applicability {#applicability}
 
-This methodology is designed to evaluate full, self-enclosed [digital-products](#digital-product), such as websites. In [Step 1.a](#step1a), evaluators define what is in scope exactly. 
+This methodology is designed to evaluate full, self-enclosed [digital products](#digital-product), such as websites. In [Step 1.a](#step1a), evaluators define what is in scope exactly. 
 
 ### Principle of Product Enclosure
 

--- a/usage.md
+++ b/usage.md
@@ -1,20 +1,39 @@
 ## Using This Methodology
 
-This methodology is used for thorough evaluation of digital products using WCAG 2. Before evaluating an entire digital product it is usually good to do a preliminary evaluation of different [samples](#sample) from the target product to identify obvious accessibility barriers and develop an overall understanding of the accessibility of the digital product. [Easy Checks - A First Review of Web Accessibility](https://www.w3.org/WAI/test-evaluate/preliminary/) describes such an approach for preliminary evaluation that is complementary to this methodology.
+This methodology is used for thorough evaluation of digital products using WCAG 2. Before evaluating an entire digital product it is usually good to do a preliminary evaluation of different [samples](#sample) from the target product to identify obvious accessibility barriers and develop an overall understanding of the accessibility of the digital product. 
+
+[Easy Checks - A First Review of Web Accessibility](https://www.w3.org/WAI/test-evaluate/preliminary/) describes such an approach for preliminary evaluation that is complementary to this methodology.
 
 ### Required Expertise {#expertise}
 
-Users of this methodology are assumed to have solid understanding of how to evaluate web content using WCAG 2, accessible web design, assistive technologies, and of how people with different disabilities use the Web. This includes an understanding of technologies; accessibility barriers that people with disabilities experience; assistive technologies and adaptive approaches that people with disabilities use; and evaluation techniques, tools, and methods to identify barriers for people with disabilities. In particular, it is assumed that users of this methodology are deeply familiar with all the resources listed in [Background Reading](#reading).
+Users of this methodology are assumed to have solid understanding of how to evaluate web content using WCAG 2, accessible web design, assistive technologies, and of how people with different disabilities use the Web. 
+
+This includes an understanding of:
+
+- technologies,
+- accessibility barriers that people with disabilities experience,
+- assistive technologies and adaptive approaches that people with disabilities use, and
+- evaluation techniques, tools, and methods to identify barriers for people with disabilities. 
+
+In particular, it is assumed that users of this methodology are deeply familiar with all the resources listed in [Background Reading](#reading).
 
 ### Combined Expertise (Optional)
 
-This methodology can be carried out by an individual evaluator with the skills described in the previous section ([Required Expertise](#expertise)), or a team of evaluators with collective expertise. Using the combined expertise of different evaluators may sometimes be necessary or beneficial when one evaluator alone does not possess all of the required expertise. [Using Combined Expertise to Evaluate Web Accessibility](https://www.w3.org/WAI/test-evaluate/combined-expertise/) provides further guidance on using combined expertise of review teams, which is beyond the scope of this document.
+This methodology can be carried out by an individual evaluator with the skills described in the previous section ([Required Expertise](#expertise)), or a team of evaluators with collective expertise. 
+
+Using the combined expertise of different evaluators may sometimes be necessary or beneficial when one evaluator alone does not possess all of the required expertise. 
+
+[Using Combined Expertise to Evaluate Web Accessibility](https://www.w3.org/WAI/test-evaluate/combined-expertise/) provides further guidance on using combined expertise of review teams.
 
 ### Involving Users (Optional)
 
-Involving people with disabilities including people with aging-related impairments (who are not experienced evaluators or part of a review team) may help identify additional accessibility barriers that are not easily discovered by expert evaluation alone. While not required for using this methodology, it is strongly recommended for evaluators to involve real people with a wide range of abilities during the evaluation process. [Involving Users in Web Accessibility Evaluation](https://www.w3.org/WAI/test-evaluate/involving-users/) provides further guidance on involving users in web accessibility evaluation, which is beyond the scope of this document.
+Involving people with disabilities (who are not experienced evaluators or part of a review team) may help identify additional accessibility barriers that are not easily discovered by expert evaluation alone. While not required for using this methodology, it is strongly recommended for evaluators to involve real people with a wide range of abilities during the evaluation process.
+
+[Involving Users in Web Accessibility Evaluation](https://www.w3.org/WAI/test-evaluate/involving-users/) provides further guidance on involving users in web accessibility evaluation.
 
 ### Evaluation Tools (Optional)
 
-This methodology is independent of any particular accessibility evaluation tool, web browser, and other software tool. While most accessibility checks are not fully automatable, evaluation tools can significantly assist evaluators during the evaluation process and contribute to more effective evaluation. For example, some accessibility evaluation tools can scan an entire digital product to help identify relevant [samples](#sample) for manual evaluation. Tools can also assist during manual (human) evaluation of accessibility checks. [Selecting Web Accessibility Evaluation Tools](https://www.w3.org/WAI/test-evaluate/tools/selecting/) provides further guidance on using tools which is beyond the scope of this document.
+This methodology is independent of any particular accessibility evaluation tool, web browser, and other software tool. While most accessibility checks are not fully automatable, evaluation tools can significantly assist evaluators during the evaluation process and contribute to more effective evaluation. For example, some accessibility evaluation tools can scan an entire digital product to help identify relevant [samples](#sample) for manual evaluation. Tools can also assist during manual (human) evaluation of accessibility checks. 
+
+[Selecting Web Accessibility Evaluation Tools](https://www.w3.org/WAI/test-evaluate/tools/selecting/) provides further guidance on using tools.
 


### PR DESCRIPTION
Made wording simpler in a bunch of places and removed some sentences that didn't really add much, so that the words that do get more focus. 

Also added more specific and explicit way of explaining that evaluating the entire product is good, and that it is recommended in cases like some apps and documents. That bit starts on [line 204](https://github.com/w3c/wai-wcag-em/pull/108/files#diff-94b72a37de2aeac46be7b559a0dc04880ee248b24529ab25c4518a154ae448acR204) (the new note under “Step 3: Select a Representative Sample”).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/108.html" title="Last updated on Oct 7, 2025, 1:01 PM UTC (fcb6b27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/108/6589d2e...fcb6b27.html" title="Last updated on Oct 7, 2025, 1:01 PM UTC (fcb6b27)">Diff</a>