### PR TITLE
[WIP] Add refs via specref

### DIFF
--- a/appendices.md
+++ b/appendices.md
@@ -1,4 +1,5 @@
-## Appendices
+<section class="appendix">
+  <h2 class="appendix">Appendices</h2>
 
 ### Background reading {#reading}
 
@@ -25,19 +26,19 @@ These are particularly important resources that outline different approaches to 
 This is the internationally recognized standard that explains how to make web content more accessible to people with disabilities. The following resources are particularly important for accessibility evaluation of digital products:
 
 * [WCAG 2 Overview](https://www.w3.org/WAI/standards-guidelines/wcag/)
-* [WCAG 2.2 Technical Specification](https://www.w3.org/TR/WCAG22)
+* [[[WCAG22]]]
 * [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
 * [Understanding WCAG 2.2](https://www.w3.org/WAI/WCAG22/Understanding/)
 * [Techniques for WCAG 2.2](https://www.w3.org/WAI/WCAG22/Techniques/)
 
 #### ICT Accessibility
-* [Guidance on Applying WCAG 2.2 to Mobile Applications (WCAG2Mobile)](https://www.w3.org/TR/wcag2mobile-22/)
-* [Guidance on Applying WCAG 2 to Non-Web Information and Communications Technologies (WCAG2ICT)](https://www.w3.org/TR/wcag2ict-22/)
+* [[[wcag2mobile-22]]]
+* [[[wcag2ict-22]]]
 
 #### Other Standards which incorporate WCAG 2 by reference 
 
 * [Section 508 of the Rehabilitation Act](https://www.access-board.gov/ict/)
-* [EN 301 549 (PDF)](https://www.etsi.org/deliver/etsi_en/301500_301599/301549/03.02.01_60/en_301549v030201p.pdf)
+* [[etsi-en-301-549]] (PDF)
 * [CAN/ASC - EN 301 549:2024](https://accessible.canada.ca/creating-accessibility-standards/canasc-en-301-5492024-accessibility-requirements-ict-products-and-services)
 
 ### Glossary
@@ -110,15 +111,13 @@ When a <a href="#view">view</a> is one of a series of views presenting a process
 </dl>
 
 
-### Contributors
+### Acknowledgements
 
 Past and present active participants of the [WCAG 2.0 Evaluation Methodology Task Force (Eval TF)](https://www.w3.org/WAI/ER/2011/eval/eval-tf) include: Shadi Abou-Zahra; Frederick Boland; Denis Boudreau; Amy Chen; Vivienne Conway; Bim Egan; Michael Elledge; Gavin Evans; Wilco Fiers; Detlev Fischer; Elizabeth Fong; Vincent François; Alistair Garrison; Emmanuelle Gutiérrez y Restrepo; Katie Haritos-Shea; Martijn Houtepen; Peter Korn; Maureen Kraft; Aurelien Levy; David MacDonald; Mary Jo Mueller; Donald Raikes; Corominas Ramon; Roberto Scano; Samuel Sirois; Sarah J Swierenga; Eric Velleman; Konstantinos Votis; Kathleen Wahlbin; Elle Waters; Richard Warren; Léonie Watson.
 
 ### References
 
 <dl>
-  <dt>ATAG20</dt>
-  <dd>Richards J, Spellman J, Treviranus J, eds (2013). Authoring Tool Accessibility Guidelines 2.0. W3C. Available at: <a href="https://www.w3.org/TR/ATAG20/">https://www.w3.org/TR/ATAG20/</a></dd>
   <dt>Easy Checks</dt>
   <dd>Lawton Henry S, ed (2014). Easy Checks - A First Review of Web Accessibility. W3C. Available at: <a href="https://www.w3.org/WAI/eval/preliminary">https://www.w3.org/WAI/eval/preliminary</a></dd>
   <dt>Essential Components of Web Accessibility</dt>
@@ -142,3 +141,5 @@ Past and present active participants of the [WCAG 2.0 Evaluation Methodology Tas
   <dt>Understanding-WCAG22</dt>
   <dd>Campbell A, Adams C, Montgomery RB, Cooper M, eds (2025). Understanding WCAG 2.2 - A guide to understanding and implementing Web Content Accessibility Guidelines 2.2. W3C. Available at: <a href="https://www.w3.org/WAI/WCAG22/Understanding/">https://www.w3.org/WAI/WCAG22/Understanding/</a></dd>
 </dl>
+
+</section>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,10 @@
     <section id="scope" data-include="scope.md" data-include-format="markdown"></section>
     <section id="procedure" data-include="procedure.md" data-include-format="markdown"></section>
     <section id="appendices" data-include="appendices.md" data-include-format="markdown"></section>
-
+    <div hidden>
+      [[[ATAG20]]]
+      [[EASYCHECKS]]
+    </div>
     <script type="application/javascript" src="https://www.w3.org/scripts/TR/fixup.js"></script>
   </body>
 </html>

--- a/respec-config.js
+++ b/respec-config.js
@@ -60,6 +60,14 @@ var respecConfig = {
 			companyURI: "https://www.w3.org",			
 		},
     ],
+	
+	localBiblio: {
+		EASYCHECKS : {
+		  title: "Easy Checks",
+		  href: "https://www.w3.org/WAI/eval/preliminary",
+		  publisher: "W3C",
+		},
+	 },
 	//authors:  [
 	//    { name: "Your Name", url: "https://example.org/",
 	//      company: "Your Company", companyURI: "https://example.com/" },


### PR DESCRIPTION
With specref references we can potentially make the references in our doc more tidy and use the automatically generated references section.

I have mixed feelings: it makes some refs better, but the ones that are not in the specref database would need to be manually added.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/136.html" title="Last updated on Nov 5, 2025, 1:23 PM UTC (0ca4ba2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/136/4b85568...0ca4ba2.html" title="Last updated on Nov 5, 2025, 1:23 PM UTC (0ca4ba2)">Diff</a>