### PR TITLE
Split up appendices

### DIFF
--- a/acknowledgements.md
+++ b/acknowledgements.md
@@ -1,0 +1,24 @@
+## Acknowledgements
+
+For the 2.0 update, contributors included
+Shadi Abou-Zahra;
+Alastair Campbell;
+Mike Gifford;
+Jan Jaap de Groot;
+Wendy Meerkerk,
+Iacobien Riezebosch;
+Eric Velleman;
+Kevin White;
+Paul van Workum.
+
+Editors also solicited feedback in evaluator interviews from 
+Roel Antonisse;
+Sacha Bogaers;
+Bram Duvigneau;
+Stefan Farnetani;
+Detlev Fischer;
+Ronny Hendriks;
+Sophie Ragas;
+Savitri Sinnema.
+
+Past and present active participants of the [WCAG 2.0 Evaluation Methodology Task Force (Eval TF)](https://www.w3.org/WAI/ER/2011/eval/eval-tf) include: Shadi Abou-Zahra; Frederick Boland; Denis Boudreau; Amy Chen; Vivienne Conway; Bim Egan; Michael Elledge; Gavin Evans; Wilco Fiers; Detlev Fischer; Elizabeth Fong; Vincent François; Alistair Garrison; Emmanuelle Gutiérrez y Restrepo; Katie Haritos-Shea; Martijn Houtepen; Peter Korn; Maureen Kraft; Aurelien Levy; David MacDonald; Mary Jo Mueller; Donald Raikes; Corominas Ramon; Roberto Scano; Samuel Sirois; Sarah J Swierenga; Eric Velleman; Konstantinos Votis; Kathleen Wahlbin; Elle Waters; Richard Warren; Léonie Watson.

--- a/background-reading.md
+++ b/background-reading.md
@@ -1,0 +1,39 @@
+## Background reading {#reading}
+
+The information below, related to accessibility essentials, evaluation, and WCAG 2 is important to use this methodology. Evaluators who use this methodology are expected to be deeply familiar with all of the listed resources.
+
+### Web Accessibility Essentials
+
+The following documents introduce the essential components of accessibility and explain how people with disabilities use the Web. They are critical to understand the broader context of accessibility evaluation:
+
+* [Essential Components of Web Accessibility](https://www.w3.org/WAI/fundamentals/components/)
+* [How People with Disabilities Use the Web](https://www.w3.org/WAI/people-use-web/)
+
+### Evaluating Digital Products for Accessibility
+
+These are particularly important resources that outline different approaches to evaluate digital products for accessibility:
+
+* [Easy Checks - A First Review of Web Accessibility](https://www.w3.org/WAI/test-evaluate/easy-checks/)
+* [Involving Users in Web Accessibility Evaluation](https://www.w3.org/WAI/test-evaluate/involving-users/)
+* [Selecting Web Accessibility Evaluation Tools](https://www.w3.org/WAI/test-evaluate/tools/selecting/)
+* [Using Combined Expertise to Evaluate Web Accessibility](https://www.w3.org/WAI/test-evaluate/combined-expertise/)
+
+### Web Content Accessibility Guidelines (WCAG) 2
+
+This is the internationally recognized standard that explains how to make web content more accessible to people with disabilities. The following resources are particularly important for accessibility evaluation of digital products:
+
+* [[WCAG2-Overview]]
+* [[[WCAG22]]]
+* [How to Meet WCAG 2 (Quick Reference)](https://www.w3.org/WAI/WCAG22/quickref/)
+* [[Understanding-WCAG22]]
+* [[WCAG22-TECHS]]
+
+### ICT Accessibility
+* [[[wcag2mobile-22]]]
+* [[[wcag2ict-22]]]
+
+### Other Standards which incorporate WCAG 2 by reference 
+
+* [Section 508 of the Rehabilitation Act](https://www.access-board.gov/ict/)
+* [[etsi-en-301-549]] (PDF)
+* [CAN/ASC - EN 301 549:2024](https://accessible.canada.ca/creating-accessibility-standards/canasc-en-301-5492024-accessibility-requirements-ict-products-and-services)

--- a/glossary.md
+++ b/glossary.md
@@ -1,0 +1,70 @@
+## Glossary
+
+For the purposes of this document, the following terms and definitions apply:
+
+<dl>
+<dt id="complete">Complete process</dt>
+<dd> Based on <a href="https://www.w3.org/TR/WCAG22/#cc3">WCAG 2.2 Conformance Requirement for Complete Processes</a>: 
+
+When a <a href="#view">view</a> is one of a series of views presenting a process (i.e., a sequence of steps that need to be completed in order to accomplish an activity), all views in the process conform at the specified level or better. (Conformance is not possible at a particular level if any view in the process does not conform at that level or better.)</dd>
+
+<dt id="conformance">Conformance</dt>
+<dd>From <a href="https://www.w3.org/TR/WCAG/#dfn-conform">WCAG 2.2 definition for "conformance"</a>:  
+<blockquote>Satisfying all the requirements of a given standard, guideline or specification.</blockquote></dd>
+
+<dt id="common">Common views</dt>
+<dd>Views that are relevant to the entire digital product. This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar views that are typically linked from all other views (usually from the header, footer, or navigation menu).
+
+<p class="note">A definition for <a href="#view">views</a> is provided below.</p></dd>
+
+<dt id="developer">Developer</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that is involved in the  development process including but not limited to content authors, designers, front-end developers, back-end programmers, quality assurance testers, and project managers.</dd>
+
+<dt id="digital-product">Digital product</dt>
+<dd>A coherent collection of one or more related views that together provide common use or functionality. It includes Web sites, web apps, e-books, kiosk apps, mobile apps and documents (PDF, Word) etc.
+
+<p class="note">The focus of this methodology is on full, self-enclosed digital products. Digital products may be composed of smaller subsets of views, each of which can be considered to be an individual product. For example, a digital product may include an online shop, an area for each department within the organization, a blog area, and other areas that may each be considered to be a digital product.</p></dd>
+
+<dt id="functionality">Essential functionality</dt>
+<dd>Functionality of a digital product that, if removed, fundamentally changes the use or purpose of the product for users. This includes information that users of a product refer to and tasks that they carry out to perform this functionality.
+<p class="note">Examples of essential functionality include “selecting and purchasing an item from an online shop”, “completing and submitting a form provided in an application”, and “registering for an account on the kiosk”.</p>
+<p class="note">Other functionality is not excluded from the scope of evaluation. The term “essential functionality” is intended to help identify critical samples and include them among others in an evaluation.</p></dd>
+
+<dt id="evaluator">Evaluator</dt>
+<dd>The person, team of people, organization, in-house department, or other entity responsible for carrying out the evaluation.</dd>
+
+<dt id="commissioner">Evaluation commissioner</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that commissioned the evaluation.
+
+<p class="note">In many cases the evaluation commissioner may be the product owner or product developer, in other cases it may be another entity such as a procurer or an accessibility monitoring survey owner.</p></dd>
+
+<dt id="relied">Relied upon (Technologies)</dt>
+
+<dd>From <a href="https://www.w3.org/TR/WCAG22/#dfn-reliedupon">WCAG 2.2 definition for "relied upon"</a>:  
+<blockquote>The content would not conform if that technology is turned off or is not supported.</blockquote></dd>
+
+<dt id="sample">Sample</dt>
+<dd><a href="#view">View</a> that is included in the <a href="#sampleset">sample set</a>.</dd>
+
+<dt id="sampleset">Sample set</dt>
+<dd>List of <a href="#sample">samples</a> selected for evaluations.</dd>
+
+
+<dt id="template">Template</dt>
+
+<dd>From <a href="https://www.w3.org/TR/ATAG20/#def-Template">ATAG 2.0 definition for "templates"</a>:  
+<blockquote>Content patterns that are filled in by authors or the authoring tool to produce web content for end users (e.g., document templates, content management templates, presentation themes). Often templates will pre-specify at least some authoring decisions.</blockquote></dd>
+
+<dt id="owner">Owner</dt>
+<dd>The person, team of people, organization, in-house department, or other entity that is responsible for the digital product.</dd>
+
+<dt id="view">View</dt>
+<dd>From WCAG 3 developing definition:  
+<blockquote>The content that is actively available in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</blockquote></dd>
+
+<dt id="webpage">Web page</dt>
+<dd>From <a href="https://www.w3.org/TR/WCAG22/#dfn-webpage">WCAG 2.2 definition for "web page"</a>:  
+<blockquote>A non-embedded resource obtained from a single URI using HTTP plus any other resources that are used in the rendering or intended to be rendered together with it by a user agent.</blockquote></dd>
+</dl>
+
+

--- a/index.html
+++ b/index.html
@@ -24,7 +24,9 @@
     <section id="usage" data-include="usage.md" data-include-format="markdown"></section>
     <section id="scope" data-include="scope.md" data-include-format="markdown"></section>
     <section id="procedure" data-include="procedure.md" data-include-format="markdown"></section>
-    <section id="appendices" data-include="appendices.md" data-include-format="markdown"></section>
+    <section id="glossary" data-include="glossary.md" data-include-format="markdown" class="appendix"></section>
+    <section id="background-reading" data-include="background-reading.md" data-include-format="markdown" class="appendix"></section>
+    <section id="acks" data-include="acknowledgements.md" data-include-format="markdown" class="appendix"></section>
     <div hidden>
       [[[ATAG20]]]
       [[Easy-Checks]]


### PR DESCRIPTION
I've used the 'proper' way to create appendices. 

Currently we have Section 5 that contains the appendices, with this change we'll have A for glossary, B for Background reading, C for Acks and D for references (which gets auto-generated). 

Benefits: 
- less heading levels
- appendices more naturally split from the main text
- easier to maintain

<img width="398" height="362" alt="table of contents bit from respec doc that shows A Glossary, B. Background reading, C. Acknowledgements D.  References" src="https://github.com/user-attachments/assets/dabf4fcd-2e69-4fd2-96c2-36b915ed8bd9" />


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/141.html" title="Last updated on Nov 7, 2025, 8:08 AM UTC (b7179f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/141/9fa7ae3...b7179f3.html" title="Last updated on Nov 7, 2025, 8:08 AM UTC (b7179f3)">Diff</a>