### PR TITLE
re-add 'view' to avoid linking to working draft developing definition

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -8,7 +8,7 @@ For the purposes of this document, the following terms and definitions apply:
 
 <p class="note">This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar views that are typically linked from all other views (usually from the header, footer, or navigation menu).</p>
 
-<p class="note">A definition for <a href="https://www.w3.org/TR/wcag-3.0/#dfn-view">views</a> is provided below.</p></dd>
+<p class="note">A definition for <a>view</a> is provided below.</p></dd>
 
 <dt><dfn id="dfn-digital-product">digital product</dfn></dt>
 <dd>coherent collection of one or more related views that together provide common use or functionality
@@ -33,8 +33,17 @@ For the purposes of this document, the following terms and definitions apply:
 <p class="note">In many cases the evaluation commissioner may be the product owner or product developer, in other cases it may be another entity such as a procurer or an accessibility monitoring survey owner.</p></dd>
 
 <dt><dfn id="dfn-sample">sample</dfn></dt>
-<dd><a href="https://www.w3.org/TR/wcag-3.0/#dfn-view">view</a> that is included in the <a>sample set</a></dd>
+<dd><a>view</a> that is included in the <a>sample set</a></dd>
 
 <dt><dfn id="dfn-sample-set">sample set</dfn></dt>
 <dd>list of <a>samples</a> selected for evaluations</dd>
+
+<dt><dfn id="dfn-view">view</dfn></dt>
+<dd>From WCAG 3 developing definition:  
+<blockquote>
+  <p>The content that is actively available in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
+  <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
+  <p class="example">Examples of “included by expansion” include, but are not limited to: expanding paragraphs, non-modal dialogs, non-modal popups, error messages that appear embedded in content (for example, an “invalid password” error message).</p>
+</blockquote></dd> 
+</dd>
 </dl>

--- a/glossary.md
+++ b/glossary.md
@@ -4,10 +4,8 @@ For the purposes of this document, the following terms and definitions apply:
 
 <dl>
   <dt><dfn id="dfn-actively-available"> actively available</dfn></dt>
-  <dd>From WCAG 3 developing definition:  
-    <blockquote>
-    available for the user to perceive and use
-    </blockquote>
+  <dd>available for the user to perceive and use
+    <p class="note">This taken from the definition being developed in WCAG 3.</p>
   </dd>
 <dt><dfn  id="dfn-common-views">common views</dfn></dt>
 <dd>views that are relevant to the entire digital product
@@ -45,11 +43,10 @@ For the purposes of this document, the following terms and definitions apply:
 <dd>list of <a>samples</a> selected for evaluations</dd>
 
 <dt><dfn id="dfn-view">view</dfn></dt>
-<dd>From WCAG 3 developing definition:  
-<blockquote>
+<dd>
   <p>The content that is <a>actively available</a> in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
   <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
   <p class="example">Examples of “included by expansion” include, but are not limited to: expanding paragraphs, non-modal dialogs, non-modal popups, error messages that appear embedded in content (for example, an “invalid password” error message).</p>
-</blockquote></dd> 
+  <p class="note">This taken from the definition being developed in WCAG 3.</p>
 </dd>
 </dl>

--- a/glossary.md
+++ b/glossary.md
@@ -44,7 +44,7 @@ For the purposes of this document, the following terms and definitions apply:
 
 <dt><dfn id="dfn-view">view</dfn></dt>
 <dd>
-  <p>The content that is <a>actively available</a> in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
+  <p>content that is <a>actively available</a> in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available</p>
   <p class="example">Examples of “included by expansion” include, but are not limited to: expanding paragraphs, non-modal dialogs, non-modal popups, error messages that appear embedded in content (for example, an “invalid password” error message).</p>
   <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
   <p class="note">This definition is taken from the definition being developed in WCAG 3.</p>

--- a/glossary.md
+++ b/glossary.md
@@ -3,7 +3,13 @@
 For the purposes of this document, the following terms and definitions apply:
 
 <dl>
-<dt><dfn  id="dfn-common-views">common views</dt>
+  <dt><dfn id="dfn-actively-available"> actively available</dfn></dt>
+  <dd>From WCAG 3 developing definition:  
+    <blockquote>
+    available for the user to perceive and use
+    </blockquote>
+  </dd>
+<dt><dfn  id="dfn-common-views">common views</dfn></dt>
 <dd>views that are relevant to the entire digital product
 
 <p class="note">This includes the home, login, and other entry points, and, where applicable, contacts, help, legal information, and similar views that are typically linked from all other views (usually from the header, footer, or navigation menu).</p>
@@ -41,7 +47,7 @@ For the purposes of this document, the following terms and definitions apply:
 <dt><dfn id="dfn-view">view</dfn></dt>
 <dd>From WCAG 3 developing definition:  
 <blockquote>
-  <p>The content that is actively available in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
+  <p>The content that is <a>actively available</a> in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
   <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
   <p class="example">Examples of “included by expansion” include, but are not limited to: expanding paragraphs, non-modal dialogs, non-modal popups, error messages that appear embedded in content (for example, an “invalid password” error message).</p>
 </blockquote></dd> 

--- a/glossary.md
+++ b/glossary.md
@@ -5,7 +5,7 @@ For the purposes of this document, the following terms and definitions apply:
 <dl>
   <dt><dfn id="dfn-actively-available"> actively available</dfn></dt>
   <dd>available for the user to perceive and use
-    <p class="note">This taken from the definition being developed in WCAG 3.</p>
+    <p class="note">This taken is from the definition being developed in WCAG 3.</p>
   </dd>
 <dt><dfn  id="dfn-common-views">common views</dfn></dt>
 <dd>views that are relevant to the entire digital product
@@ -45,8 +45,8 @@ For the purposes of this document, the following terms and definitions apply:
 <dt><dfn id="dfn-view">view</dfn></dt>
 <dd>
   <p>The content that is <a>actively available</a> in a viewport, including that which can be scrolled or panned to, and any additional content that is included by expansion, while leaving the rest of the content in the viewport actively available.</p>
-  <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
   <p class="example">Examples of “included by expansion” include, but are not limited to: expanding paragraphs, non-modal dialogs, non-modal popups, error messages that appear embedded in content (for example, an “invalid password” error message).</p>
-  <p class="note">This taken from the definition being developed in WCAG 3.</p>
+  <p class="note">A modal dialog box would constitute a new view because the other content in the viewport is no longer actively available.</p>
+  <p class="note">This definition is taken from the definition being developed in WCAG 3.</p>
 </dd>
 </dl>


### PR DESCRIPTION
I think we should not link to WCAG 3 yet for the definition while it is in progress (which we started doing in https://github.com/w3c/wai-wcag-em/pull/187), so I added 'view' and 'actively available' back into WCAG-EM.

Likelihood is that we'll make improvements to “view” either way, while we are we can keep definitions in sync between the two documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/189.html" title="Last updated on Mar 26, 2026, 1:12 PM UTC (d3ad527)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/189/70b95c8...d3ad527.html" title="Last updated on Mar 26, 2026, 1:12 PM UTC (d3ad527)">Diff</a>