### PR TITLE
remove respec numbering to avoid redundant numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
       .procedure-steps li:not(:last-child) { margin-bottom: 54px; }
       .procedure-steps li:not(:last-child)::after { content: ''; background-image: url(images/arrows.svg); display: block; height: 50px; width: 80px; position: absolute; left: 0; top: calc(100% + 4px); }
       .procedure-steps li::before { content: "Step " counter(list-item); background: var(--procedure-color-dark); padding: var(--procedure-space) 1em; margin: calc(-1 * var(--procedure-space)); margin-right: 1em; font-weight: bold; color: white; }
+      .toc { margin-left: 0rem !important; } /* to compensate for removal of section numbering, inline version  */
+      body:not(.toc-inline) :not(li) > .toc { margin-left: 1rem !important; /* to compensate for removal of section numbering, in content version  */ }
     </style>
   </head>
 

--- a/respec-config.js
+++ b/respec-config.js
@@ -60,7 +60,7 @@ var respecConfig = {
 			companyURI: "https://www.w3.org",			
 		},
     ],
-
+	
 	localBiblio: {
 		"Easy-Checks" : {
 		  title: "Easy Checks - A First Review of Web Accessibility",
@@ -139,6 +139,8 @@ var respecConfig = {
 		() => {
 			// Remove stray <p> elements added by Markdown between dt/dd elements
 			document.querySelectorAll("dl > p:empty").forEach((el) => el.remove());
+			// Remove all of respec's section numbers, to avoid confusion with our manual step numbering
+			document.querySelectorAll('.secno').forEach(el => el.remove());
 		}
 	]
 };


### PR DESCRIPTION
fixes #160


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/pull/190.html" title="Last updated on Mar 26, 2026, 7:24 PM UTC (8d762d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wai-wcag-em/190/aa312b9...8d762d3.html" title="Last updated on Mar 26, 2026, 7:24 PM UTC (8d762d3)">Diff</a>